### PR TITLE
chore: update references to github-workflows repo

### DIFF
--- a/.github/workflows/auto-merge.yaml
+++ b/.github/workflows/auto-merge.yaml
@@ -22,7 +22,7 @@ name: 'Auto merge'
 
 jobs:
   auto-merge:
-    uses: enterprise-contract/github-workflows/.github/workflows/auto-merge.yaml@main
+    uses: conforma/github-workflows/.github/workflows/auto-merge.yaml@main
     secrets: inherit
     permissions:
       pull-requests: write


### PR DESCRIPTION
This commit updates references to the github-workflows from `enterprise-contract/github-workflows` to `conforma/github-workflows`.

Ref: EC-1118