### PR TITLE
docs: indicate deprecation of enterprise-contract

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,3 +1,9 @@
+> [!IMPORTANT]
+> This project has a new home! Please find us at [github.com/conforma](https://github.com/conforma).
+
+> [!NOTE]
+> Please update your references to the appropriate repository in the [Conforma](https://github.com/conforma) organization.
+
 # Contributor Covenant Code of Conduct
 
 ## Our Pledge

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,9 @@
+> [!IMPORTANT]
+> This project has a new home! Please find us at [github.com/conforma](https://github.com/conforma).
+
+> [!NOTE]
+> Please update your references to the appropriate repository in the [Conforma](https://github.com/conforma) organization.
+
 # Contributing
 
 Enterprise Contract welcomes contributions in many forms. [Pull requests](https://docs.github.com/en/get-started/quickstart/github-glossary#pull-request) are specifically appreciated and the maintainers will make every effort to assist with any issues in the pull request discussion. Feel free to create a pull request even if you are new to the process. If you need more information, see [this article](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request) about how creating a pull request.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+> [!IMPORTANT]
+> This project has a new home! Please find us at [github.com/conforma](https://github.com/conforma).
+
+> [!NOTE]
+> Please update your references to the appropriate repository in the [Conforma](https://github.com/conforma) organization.
+
 # .github
 
 This repository stores GitHub specific information that applies to all the repositories within the

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,3 +1,9 @@
+> [!IMPORTANT]
+> This project has a new home! Please find us at [github.com/conforma](https://github.com/conforma).
+
+> [!NOTE]
+> Please update your references to the appropriate repository in the [Conforma](https://github.com/conforma) organization.
+
 # Security Policy
 
 ## Reporting a Vulnerability

--- a/profile/README.md
+++ b/profile/README.md
@@ -1,6 +1,10 @@
+> [!IMPORTANT]
+> This project has a new home! Please find us at [github.com/conforma](https://github.com/conforma).
+
+> [!NOTE]
+> Please update your references to the appropriate repository in the [Conforma](https://github.com/conforma) organization.
+
+
 Engage with the Conforma team by filing an issue in one of the repositories in [this GitHub organization](https://github.com/enterprise-contract/).
 
 Our [documentation](https://conforma.dev/docs/) may already have the answer you are looking for.
-
-> [!NOTE]
-> Conforma was previously known as "Enterprise Contract". Please bear with us as we transition from the old name to the new name, and move our code to its new home in the [Conforma GitHub organization](https://github.com/conforma/).


### PR DESCRIPTION
This commit updates the various markdown files in this repository to indicate that this organization is now deprecated and references should be updated to the new Conforma organization.

Ref: EC-1125